### PR TITLE
Fixed JS calls for D8

### DIFF
--- a/field_group_ajaxified_multipage.libraries.yml
+++ b/field_group_ajaxified_multipage.libraries.yml
@@ -1,0 +1,5 @@
+field_group_ajaxified_multipage:
+  js:
+    js/field_group_ajaxified_multipage.js: {}
+  dependencies:
+    - core/jquery

--- a/field_group_ajaxified_multipage.module
+++ b/field_group_ajaxified_multipage.module
@@ -320,7 +320,7 @@ function field_group_ajaxified_multipage_form_alter(&$form, &$form_state, $form_
 
     // Scroll to top.
     if ($scroll_top) {
-      $form['#attached']['js'][] = drupal_get_path('module', 'field_group_ajaxified_multipage') . '/js/field_group_ajaxified_multipage.js';
+      $form['#attached']['library'][] = 'field_group_ajaxified_multipage/field_group_ajaxified_multipage';
     }
 
     // Allow thirdparty modules to alter the altered form array.

--- a/js/field_group_ajaxified_multipage.js
+++ b/js/field_group_ajaxified_multipage.js
@@ -1,17 +1,17 @@
-(function($){
+/**
+ * @file
+ * field_group_ajaxified_multipage.js
+ */
 
-    /**
+(function ($, Drupal) {
+  /**
    * Scroll to top.
    */
-    Drupal.behaviors.scrollTop = {
-        attach: function (context, settings) {
-
-            $('html, body').animate(
-                {
-                    scrollTop: $("body").offset().top
-                }, 200
-            );
-
-        }
-    };
-})(jQuery);
+  Drupal.behaviors.scrollTop = {
+    attach: function (context, settings) {
+      $('html, body').animate({
+        scrollTop: $("body").offset().top
+      }, 200);
+    }
+  };
+})(jQuery, Drupal);


### PR DESCRIPTION
In Drupal 8 you cannot add inline JS to an element's #attached array. It
must be done via a library. I have changed the code so the JS is called
and used as a library